### PR TITLE
read only option added to controllers and authenticator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -67,7 +67,6 @@ spec:
           args:
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=127.0.0.1:8080"
-            - "--leader-elect"
             - "--address=0.0.0.0:8082"
             - "--tls-key-path=/opt/cert/tls.key"
             - "--tls-cert-path=/opt/cert/tls.crt"

--- a/controllers/accesstoken_controller.go
+++ b/controllers/accesstoken_controller.go
@@ -51,7 +51,7 @@ type AccessTokenReconciler struct {
 func (r *AccessTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	err := r.Cache.UpdateCache(r.Client, ctx)
+	err := r.Cache.UpdateCache(r.Client, ctx, r.ReadOnly)
 
 	return ctrl.Result{}, err
 }

--- a/controllers/accesstoken_controller.go
+++ b/controllers/accesstoken_controller.go
@@ -30,8 +30,9 @@ import (
 // AccessTokenReconciler reconciles a AccessToken object
 type AccessTokenReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Cache  ProcessCache
+	Scheme   *runtime.Scheme
+	Cache    ProcessCache
+	ReadOnly bool
 }
 
 //+kubebuilder:rbac:groups=cerberus.snappcloud.io,resources=accesstokens,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/cache.go
+++ b/controllers/cache.go
@@ -7,5 +7,5 @@ import (
 )
 
 type ProcessCache interface {
-	UpdateCache(client.Client, context.Context) error
+	UpdateCache(client.Client, context.Context, bool) error
 }

--- a/controllers/webservice_controller.go
+++ b/controllers/webservice_controller.go
@@ -30,8 +30,9 @@ import (
 // WebServiceReconciler reconciles a WebService object
 type WebServiceReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Cache  ProcessCache
+	Scheme   *runtime.Scheme
+	Cache    ProcessCache
+	ReadOnly bool
 }
 
 //+kubebuilder:rbac:groups=cerberus.snappcloud.io,resources=webservices,verbs=get;list;watch;create;update;patch;delete
@@ -50,7 +51,7 @@ type WebServiceReconciler struct {
 func (r *WebServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	err := r.Cache.UpdateCache(r.Client, ctx)
+	err := r.Cache.UpdateCache(r.Client, ctx, r.ReadOnly)
 
 	return ctrl.Result{}, err
 }

--- a/controllers/webserviceaccessbinding_controller.go
+++ b/controllers/webserviceaccessbinding_controller.go
@@ -30,8 +30,9 @@ import (
 // WebserviceAccessBindingReconciler reconciles a WebserviceAccessBinding object
 type WebserviceAccessBindingReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Cache  ProcessCache
+	Scheme   *runtime.Scheme
+	Cache    ProcessCache
+	ReadOnly bool
 }
 
 //+kubebuilder:rbac:groups=cerberus.snappcloud.io,resources=webserviceaccessbindings,verbs=get;list;watch;create;update;patch;delete
@@ -50,7 +51,7 @@ type WebserviceAccessBindingReconciler struct {
 func (r *WebserviceAccessBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	err := r.Cache.UpdateCache(r.Client, ctx)
+	err := r.Cache.UpdateCache(r.Client, ctx, r.ReadOnly)
 
 	return ctrl.Result{}, err
 }

--- a/main.go
+++ b/main.go
@@ -150,25 +150,28 @@ func setupManager(
 	setupLog.Info(fmt.Sprintf("authenticator: %v", cache))
 
 	if err = (&controllers.AccessTokenReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Cache:  cache,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Cache:    cache,
+		ReadOnly: !enableLeaderElection,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AccessToken")
 		return nil, err
 	}
 	if err = (&controllers.WebServiceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Cache:  cache,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Cache:    cache,
+		ReadOnly: !enableLeaderElection,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WebService")
 		return nil, err
 	}
 	if err = (&controllers.WebserviceAccessBindingReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Cache:  cache,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Cache:    cache,
+		ReadOnly: !enableLeaderElection,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WebserviceAccessBinding")
 		return nil, err

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -51,7 +51,7 @@ const (
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // TODO add Secrets to be watched
-func (a *Authenticator) UpdateCache(c client.Client, ctx context.Context) error {
+func (a *Authenticator) UpdateCache(c client.Client, ctx context.Context, readOnly bool) error {
 	a.updateLock.Lock()
 	defer a.updateLock.Unlock()
 
@@ -135,11 +135,6 @@ func (a *Authenticator) UpdateCache(c client.Client, ctx context.Context) error 
 	return nil
 }
 
-// TODO reconcile on secret change (list of secrets can be obtained during cahceUpdates)
-// func (a *Authenticator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
-// }
-
 func (a *Authenticator) TestAccess(wsvc string, token string) (bool, CerberusReason) {
 	a.cacheLock.RLock()
 	defer a.cacheLock.RUnlock()
@@ -196,9 +191,3 @@ func NewAuthenticator(logger logr.Logger) (*Authenticator, error) {
 	}
 	return &a, nil
 }
-
-// func (a *Authenticator) RegisterWithManager(mgr ctrl.Manager) error {
-// 	return ctrl.NewControllerManagedBy(mgr).
-// 		For(&v1.Secret{}).
-// 		Complete(a)
-// }


### PR DESCRIPTION
Now if we run an instance of Cerberus with --leader-elect=false the instance will act as a readonly authenticator server. It might be useful for high throughput environments.