### PR TITLE
Cached and use lookup header for authenticate req

### DIFF
--- a/api/v1alpha1/webservice_types.go
+++ b/api/v1alpha1/webservice_types.go
@@ -29,8 +29,8 @@ type WebServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// +kubebuilder:default=X-Cerberus-Token
-	// +kubebuilder:validation:Pattern=^(X-.*|Authorization)$
-	// LookupHeader tells Cerberus which header should be used as access token for the authentication
+	// +kubebuilder:validation:Pattern=^(X-[A-Za-z-]*[A-Za-z]|Authorization)$
+	// LookupHeader tells Cerberus which header should be used as the access token for authentication (case-sensitive).
 	LookupHeader string `json:"lookupHeader,omitempty"`
 
 	// UpstreamHttpAuth tells Cerberus whether it needs to forward

--- a/api/v1alpha1/webservice_types.go
+++ b/api/v1alpha1/webservice_types.go
@@ -28,6 +28,8 @@ type WebServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +kubebuilder:default=X-Cerberus-Token
+	// +kubebuilder:validation:Pattern=^(X-.*|Authorization)$
 	// LookupHeader tells Cerberus which header should be used as access token for the authentication
 	LookupHeader string `json:"lookupHeader,omitempty"`
 

--- a/api/v1alpha1/webservice_types.go
+++ b/api/v1alpha1/webservice_types.go
@@ -28,7 +28,7 @@ type WebServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// LookupHeader tells Cerberus which header should be used as Webservice name for the authentication
+	// LookupHeader tells Cerberus which header should be used as access token for the authentication
 	LookupHeader string `json:"lookupHeader,omitempty"`
 
 	// UpstreamHttpAuth tells Cerberus whether it needs to forward

--- a/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
+++ b/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
@@ -36,9 +36,11 @@ spec:
             description: WebServiceSpec defines the desired state of WebService
             properties:
               lookupHeader:
+                default: 'X-Cerberus-Token'
                 description: LookupHeader tells Cerberus which header should be used
                   as access token for the authentication
                 type: string
+                pattern: '^(X-.*|Authorization)$'
               upstreamHttpAuth:
                 description: UpstreamHttpAuth tells Cerberus whether it needs to forward
                   authentication to another (HTTP) service or not

--- a/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
+++ b/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
@@ -37,7 +37,7 @@ spec:
             properties:
               lookupHeader:
                 description: LookupHeader tells Cerberus which header should be used
-                  as Webservice name for the authentication
+                  as access token for the authentication
                 type: string
               upstreamHttpAuth:
                 description: UpstreamHttpAuth tells Cerberus whether it needs to forward

--- a/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
+++ b/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
@@ -36,11 +36,11 @@ spec:
             description: WebServiceSpec defines the desired state of WebService
             properties:
               lookupHeader:
-                default: 'X-Cerberus-Token'
+                default: X-Cerberus-Token
                 description: LookupHeader tells Cerberus which header should be used
                   as access token for the authentication
+                pattern: ^(X-.*|Authorization)$
                 type: string
-                pattern: '^(X-.*|Authorization)$'
               upstreamHttpAuth:
                 description: UpstreamHttpAuth tells Cerberus whether it needs to forward
                   authentication to another (HTTP) service or not

--- a/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
+++ b/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
@@ -38,7 +38,7 @@ spec:
               lookupHeader:
                 default: X-Cerberus-Token
                 description: LookupHeader tells Cerberus which header should be used
-                  as access token for the authentication
+                  as the access token for authentication (case-sensitive).
                 pattern: ^(X-[A-Za-z-]*[A-Za-z]|Authorization)$
                 type: string
               upstreamHttpAuth:

--- a/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
+++ b/config/crd/bases/cerberus.snappcloud.io_webservices.yaml
@@ -39,7 +39,7 @@ spec:
                 default: X-Cerberus-Token
                 description: LookupHeader tells Cerberus which header should be used
                   as access token for the authentication
-                pattern: ^(X-.*|Authorization)$
+                pattern: ^(X-[A-Za-z-]*[A-Za-z]|Authorization)$
                 type: string
               upstreamHttpAuth:
                 description: UpstreamHttpAuth tells Cerberus whether it needs to forward

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -177,14 +177,14 @@ func (a *Authenticator) TestAccess(wsvc string, token string) (bool, CerberusRea
 
 func (a *Authenticator) readToken(request *Request) (bool, CerberusReason, string) {
 	wsvc := request.Context["webservice"]
-	_, ok := (*a.servicesCache)[wsvc]
+	res, ok := (*a.servicesCache)[wsvc]
 	if !ok {
 		return false, CerberusReasonWebserviceNotFound, ""
 	}
-	if (*a.servicesCache)[wsvc].Spec.LookupHeader == "" {
+	if res.Spec.LookupHeader == "" {
 		return false, CerberusReasonLookupIdentifierEmpty, ""
 	}
-	token := request.Request.Header.Get((*a.servicesCache)[wsvc].Spec.LookupHeader)
+	token := request.Request.Header.Get(res.Spec.LookupHeader)
 	return true, "", token
 }
 
@@ -197,9 +197,9 @@ func (a *Authenticator) Check(ctx context.Context, request *Request) (*Response,
 
 	if ok {
 		ok, reason, extraHeaders = a.TestAccess(wsvc, token)
-		a.logger.Info("checking request", "res(ok)", ok, "req", request)
 	}
 
+	a.logger.Info("checking request", "reason", reason, "req", request)
 	if ok {
 		httpStatusCode = http.StatusOK
 	} else {

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -33,7 +33,7 @@ type AccessCacheEntry struct {
 }
 
 type ServicesCacheEntry struct {
-	cerberusv1alpha1.WebServiceSpec
+	cerberusv1alpha1.WebService
 }
 
 type CerberusReason string
@@ -129,7 +129,7 @@ func (a *Authenticator) UpdateCache(c client.Client, ctx context.Context, readOn
 	newServicesCache := make(ServicesCache)
 	for _, webservice := range webservices.Items {
 		newServicesCache[webservice.Name] = ServicesCacheEntry{
-			WebServiceSpec: webservice.Spec,
+			WebService: webservice,
 		}
 	}
 
@@ -176,7 +176,7 @@ func (a *Authenticator) TestAccess(wsvc string, token string) (bool, CerberusRea
 
 func (a *Authenticator) Check(ctx context.Context, request *Request) (*Response, error) {
 	wsvc := request.Context["webservice"]
-	token := request.Request.Header.Get((*a.servicesCache)[wsvc].LookupHeader)
+	token := request.Request.Header.Get((*a.servicesCache)[wsvc].Spec.LookupHeader)
 
 	ok, reason, extraHeaders := a.TestAccess(wsvc, token)
 	a.logger.Info("checking request", "res(ok)", ok, "req", request)


### PR DESCRIPTION
Lookup header functionality added to Cerberus.
Now we can specify which header should be used to read token from.