### PR TITLE
Change contour extensionservice scope to cluster-admin resources and fix its protocol

### DIFF
--- a/config/cluster-admin-resources/kustomization.yaml
+++ b/config/cluster-admin-resources/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - namespace.yaml
 
 bases:
+  - ../contour
   - ../crd
   - ../rbac

--- a/config/contour/extention.yaml
+++ b/config/contour/extention.yaml
@@ -3,7 +3,7 @@ kind: ExtensionService
 metadata:
   name: cerberus-auth
 spec:
-  protocol: h2
+  protocol: h2c
   services:
     - name: cerberus
       port: 8082

--- a/config/namespace-admin-resources/kustomization.yaml
+++ b/config/namespace-admin-resources/kustomization.yaml
@@ -15,7 +15,6 @@ namespace: cerberus-operator-system
 bases:
   - ../manager
   - ../samples
-  - ../contour
   - ../prometheus
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml


### PR DESCRIPTION
This change moves the ExtensionService resource under cluster-admin scoped resources since it is related to the Contour, and also sets the protocol to h2c as the server no longer supports TLS.