### PR TITLE
Add headers on access limit

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -44,7 +44,7 @@ func (a *authV2) Check(ctx context.Context, check *CheckRequestV2) (*CheckRespon
 	final_response := response.AsV2()
 
 	// update metrics
-	reason := CerberusReason(response.Response.Header.Get("X-Cerberus-Reason"))
+	reason := CerberusReason(response.Response.Header.Get(CerberusHeaderReasonHeader))
 	labels := AddReasonLabel(nil, reason)
 	labels = AddUpstreamAuthLabel(labels, request.Context[HasUpstreamAuth])
 	labels[CheckRequestVersionLabel] = MetricsCheckRequestVersion2
@@ -70,7 +70,7 @@ func (a *authV3) Check(ctx context.Context, check *CheckRequestV3) (*CheckRespon
 	final_response := response.AsV3()
 
 	// update metrics
-	reason := CerberusReason(response.Response.Header.Get("X-Cerberus-Reason"))
+	reason := CerberusReason(response.Response.Header.Get(CerberusHeaderReasonHeader))
 	labels := AddReasonLabel(nil, reason)
 	labels = AddUpstreamAuthLabel(labels, request.Context[HasUpstreamAuth])
 	labels[CheckRequestVersionLabel] = MetricsCheckRequestVersion3


### PR DESCRIPTION
It will add more visibility for API users by adding a message, priority and and minimum priority to inform users why they get limited to access the webservice they are requesting. I also done some refactors to minimize possible mistakes and more readability.