### PR TITLE
Add default  access token to webservice

### DIFF
--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -83,8 +83,11 @@ func (a *Authenticator) TestAccess(request *Request, wsvc WebservicesCacheEntry)
 	defer cacheReaders.Dec()
 
 	if token == "" {
-		reason = CerberusReasonTokenEmpty
-		return
+		if wsvc.defaultAccessToken == NoDefaultAccessToken {
+			reason = CerberusReasonTokenEmpty
+			return
+		}
+		token = wsvc.defaultAccessToken
 	}
 
 	ac, ok := a.accessTokensCache.ReadAccessToken(token)


### PR DESCRIPTION
I have added an annotation called `cerberus.snappcloud.io/default-access-token` over webservices and if it is set Cerberus will use it's value as default access token header value