### PR TITLE
Add handling for 529 (ServiceIsOverloaded) responses returned by Validator service

### DIFF
--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/go-logr/logr"
+	"github.com/snapp-incubator/Cerberus/api/v1alpha1"
+	"github.com/snapp-incubator/Cerberus/internal/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/snapp-incubator/Cerberus/api/v1alpha1"
-	"github.com/snapp-incubator/Cerberus/internal/tracing"
 )
 
 // downstreamDeadlineOffset sets an offset to downstream deadline inorder

--- a/pkg/auth/cerberus_reasons.go
+++ b/pkg/auth/cerberus_reasons.go
@@ -100,4 +100,8 @@ const (
 	// CerberusReasonUpstreamAuthNoReq means that cerberus failed to create
 	// request for specified upstream auth
 	CerberusReasonUpstreamAuthNoReq CerberusReason = "upstream-auth-no-request"
+
+	// CerberusReasonUpstreamAuthServiceIsOverloaded indicates that the upstream authentication service
+	// is currently overloaded and unable to process new requests
+	CerberusReasonUpstreamAuthServiceIsOverloaded CerberusReason = "upstream-service-is-overloaded"
 )


### PR DESCRIPTION
This change adds handling for the custom HTTP status 529 (ServiceIsOverloaded) returned by the Validator service.
When this status is received, the service now responds with 503 (Service Unavailable) instead of 401 (Unauthorized) to indicate a temporary overload condition rather than an authentication failure.