### PR TITLE
feat(auth): copy tenant ID header to upstream auth when env set

### DIFF
--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -35,6 +35,12 @@ func getServiceName() string {
 	return "cerberus"
 }
 
+// getTenantIDHeader returns the header name to copy from request to upstream auth from env TENANT_ID_HEADER.
+// If unset, returns empty string and no header is copied.
+func getTenantIDHeader() string {
+	return os.Getenv("TENANT_ID_HEADER")
+}
+
 // Authenticator can generate cache from Kubernetes API server
 // and it implements envoy.CheckRequest interface
 type Authenticator struct {
@@ -379,6 +385,11 @@ func setupUpstreamAuthRequest(upstreamHttpAuth *v1alpha1.UpstreamHttpAuthService
 		upstreamHttpAuth.WriteTokenTo: {token},
 		"X-Service-Name":              {svcName},
 		"Content-Type":                {"application/json"},
+	}
+	if tenantIDHeader := getTenantIDHeader(); tenantIDHeader != "" {
+		if v := request.Request.Header.Get(tenantIDHeader); v != "" {
+			req.Header.Set(tenantIDHeader, v)
+		}
 	}
 	return req, nil
 }


### PR DESCRIPTION
Add TENANT_ID_HEADER env: when set, the named header is copied from the incoming request to the upstream auth HTTP request; when unset, behavior is unchanged.

- getTenantIDHeader() reads header name from TENANT_ID_HEADER
- setupUpstreamAuthRequest copies that header if present on the request
- Table-driven test covers: copy when set, omit when header missing, no-op when env unset
- Base TestSetupUpstreamAuthRequest unsets env so baseline is deterministic

AI-Assisted: true
AI-Model: Auto